### PR TITLE
bugfix: a typo in a function call removeChangeListener

### DIFF
--- a/scripts/components/hello-world.jsx
+++ b/scripts/components/hello-world.jsx
@@ -19,7 +19,7 @@ export default class HelloWorld extends React.Component {
 	}
 
 	componentWillUnmount() {
-		HelloStore.addRemoveListener(this._onChange.bind(this));
+		HelloStore.removeChangeListener(this._onChange.bind(this));
 	}
 
 	_onChange() {


### PR DESCRIPTION
I think you mean `removeChangeListener` instead of `addRemoveListener`...

By the way, when you remove the listener, the `cb` parameter is `this._onChange.bind(this)`.

On the store function, if you call `this.listeners('CHANGE')`, you will see that the callback is still there, even after calling the `HelloStore.removeChangeListener(...)` because when you give the parameter `this._onChange.bind(this)`, you give a new instance of the function `this._onChange` which it is not what you want to do.
